### PR TITLE
recover the starting URL when the user returns to alphawing

### DIFF
--- a/app/controllers/alphawing.go
+++ b/app/controllers/alphawing.go
@@ -57,10 +57,7 @@ func (c AlphaWingController) Index() revel.Result {
 }
 
 func (c AlphaWingController) GetLogin() revel.Result {
-	next := c.Params.Query.Get("next")
-	if next == "" {
-		next = routes.AlphaWingController.Index()
-	}
+	next := extractPath(c.Params.Query.Get("next"))
 
 	if c.isLogin() {
 		return c.Redirect(next)
@@ -89,7 +86,7 @@ func (c AlphaWingController) GetCallback() revel.Result {
 		panic("invalid session key")
 	}
 	delete(c.Session, OAuthSessionKey)
-	next := state.Get("next")
+	next := extractPath(state.Get("next"))
 
 	code := c.Params.Query.Get("code")
 	t := c.transport()
@@ -290,6 +287,14 @@ func (c *AlphaWingController) userGoogleService() (*models.GoogleService, error)
 	}
 
 	return s, nil
+}
+
+func extractPath(next string) string {
+	n, err := url.Parse(next)
+	if err != nil {
+		return routes.AlphaWingController.Index()
+	}
+	return n.Path
 }
 
 // ----------------------------------------------------------------------

--- a/app/controllers/alphawing.go
+++ b/app/controllers/alphawing.go
@@ -104,7 +104,7 @@ func (c AlphaWingController) GetCallback() revel.Result {
 	if c.Validation.HasErrors() {
 		c.Validation.Keep()
 		c.FlashParams()
-		return c.Redirect(next)
+		return c.Redirect(routes.AlphaWingController.Index())
 	}
 
 	user, err := models.FindOrCreateUser(c.Txn, tokeninfo.Email)

--- a/app/controllers/auth.go
+++ b/app/controllers/auth.go
@@ -1,15 +1,21 @@
 package controllers
 
-import r "github.com/revel/revel"
+import (
+	"github.com/kayac/alphawing/app/routes"
+	r "github.com/revel/revel"
+	"net/url"
+)
 
 type AuthController struct {
 	AlphaWingController
 }
 
 func (c *AuthController) CheckLogin() r.Result {
-	if !c.isLogin() {
-		url := c.OAuthConfig.AuthCodeURL("")
-		return c.Redirect(url)
+	if c.isLogin() {
+		return nil
 	}
-	return nil
+
+	loginUrl := routes.AlphaWingController.GetLogin()
+	next := c.Request.URL.Path
+	return c.Redirect(loginUrl + "?next=" + url.QueryEscape(next))
 }


### PR DESCRIPTION
https://github.com/kayac/alphawing/issues/5 の対応です。

- `AuthCodeURL`に渡す`state`に、元いたURLを入れるようにしました
- `state` にはCSRF対策のためにセッション毎に異なるtokenも含めるようにしました
  ([Create an anti-forgery state token](https://developers.google.com/accounts/docs/OpenIDConnect#createxsrftoken ))
