### PR TITLE
トランザクションの範囲を小さくする

### DIFF
--- a/app/controllers/api.go
+++ b/app/controllers/api.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/kayac/alphawing/app/models"
 
-	"github.com/coopernurse/gorp"
 	"github.com/revel/revel"
 )
 
@@ -64,10 +63,7 @@ func (c ApiController) PostUploadBundle(token string, description string, file *
 		File:        file,
 	}
 
-	err = Transact(func(txn gorp.SqlExecutor) error {
-		return app.CreateBundle(txn, c.GoogleService, Conf.AaptPath, bundle)
-	})
-	if err != nil {
+	if err := app.CreateBundle(Dbm, c.GoogleService, Conf.AaptPath, bundle); err != nil {
 		if aperr, ok := err.(*models.ApkParseError); ok {
 			c.Response.Status = http.StatusInternalServerError
 			return c.RenderJson(c.NewJsonResponseUploadBundle(c.Response.Status, []string{aperr.Error()}, nil))

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kayac/alphawing/app/models"
 	"github.com/kayac/alphawing/app/routes"
 
+	"github.com/coopernurse/gorp"
 	"github.com/revel/revel"
 )
 
@@ -37,18 +38,21 @@ func (c AppController) PostCreateApp(app models.App) revel.Result {
 		return c.Redirect(routes.AppController.GetCreateApp())
 	}
 
-	if err := models.CreateApp(c.Txn, c.GoogleService, &app); err != nil {
-		panic(err)
-	}
+	err := Transact(func(txn gorp.SqlExecutor) error {
+		if err := models.CreateApp(txn, c.GoogleService, &app); err != nil {
+			return err
+		}
 
-	tokeninfo, err := c.tokenInfo()
+		tokeninfo, err := c.tokenInfo()
+		if err != nil {
+			return err
+		}
+		authority := &models.Authority{
+			Email: tokeninfo.Email,
+		}
+		return app.CreateAuthority(txn, c.GoogleService, authority)
+	})
 	if err != nil {
-		panic(err)
-	}
-	authority := &models.Authority{
-		Email: tokeninfo.Email,
-	}
-	if err := app.CreateAuthority(c.Txn, c.GoogleService, authority); err != nil {
 		panic(err)
 	}
 
@@ -65,12 +69,12 @@ func (c AppController) PostCreateApp(app models.App) revel.Result {
 func (c AppControllerWithValidation) GetApp(appId int) revel.Result {
 	app := c.App
 
-	authorities, err := app.Authorities(c.Txn)
+	authorities, err := app.Authorities(Dbm)
 	if err != nil {
 		panic(err)
 	}
 
-	bundles, err := app.Bundles(c.Txn)
+	bundles, err := app.Bundles(Dbm)
 	if err != nil {
 		panic(err)
 	}
@@ -96,7 +100,10 @@ func (c AppControllerWithValidation) PostUpdateApp(appId int, app models.App) re
 		return c.Redirect(routes.AppControllerWithValidation.GetUpdateApp(app.Id))
 	}
 
-	if err := app.Update(c.Txn); err != nil {
+	err := Transact(func(txn gorp.SqlExecutor) error {
+		return app.Update(txn)
+	})
+	if err != nil {
 		panic(err)
 	}
 
@@ -114,7 +121,10 @@ func (c AppControllerWithValidation) PostRefreshToken(appId int, app models.App)
 		c.Redirect(routes.AppControllerWithValidation.GetApp(app.Id))
 	}
 
-	if err := app.RefreshToken(c.Txn); err != nil {
+	err := Transact(func(txn gorp.SqlExecutor) error {
+		return app.RefreshToken(txn)
+	})
+	if err != nil {
 		panic(err)
 	}
 
@@ -125,7 +135,12 @@ func (c AppControllerWithValidation) PostRefreshToken(appId int, app models.App)
 func (c AppControllerWithValidation) PostDeleteApp(appId int) revel.Result {
 	app := c.App
 
-	app.Delete(c.Txn, c.GoogleService)
+	err := Transact(func(txn gorp.SqlExecutor) error {
+		return app.Delete(txn, c.GoogleService)
+	})
+	if err != nil {
+		panic(err)
+	}
 
 	if err := c.createAudit(models.ResourceApp, appId, models.ActionDelete); err != nil {
 		panic(err)
@@ -159,7 +174,10 @@ func (c AppControllerWithValidation) PostCreateBundle(appId int, bundle models.B
 		bundle.FileName = c.Params.Files["file"][0].Filename
 	}
 
-	if err := c.App.CreateBundle(c.Txn, c.GoogleService, Conf.AaptPath, &bundle); err != nil {
+	err := Transact(func(txn gorp.SqlExecutor) error {
+		return c.App.CreateBundle(txn, c.GoogleService, Conf.AaptPath, &bundle)
+	})
+	if err != nil {
 		if aperr, ok := err.(*models.ApkParseError); ok {
 			c.Flash.Error(aperr.Error())
 			return c.Redirect(routes.AppControllerWithValidation.GetCreateBundle(appId))
@@ -186,7 +204,7 @@ func (c AppControllerWithValidation) PostCreateAuthority(appId int, email string
 		return c.Redirect(routes.AppControllerWithValidation.GetApp(appId))
 	}
 
-	found, err := app.HasAuthorityForEmail(c.Txn, email)
+	found, err := app.HasAuthorityForEmail(Dbm, email)
 	if err != nil {
 		panic(err)
 	}
@@ -200,7 +218,13 @@ func (c AppControllerWithValidation) PostCreateAuthority(appId int, email string
 	authority := &models.Authority{
 		Email: email,
 	}
-	app.CreateAuthority(c.Txn, c.GoogleService, authority)
+
+	err = Transact(func(txn gorp.SqlExecutor) error {
+		return app.CreateAuthority(txn, c.GoogleService, authority)
+	})
+	if err != nil {
+		panic(err)
+	}
 
 	if err := c.createAudit(models.ResourceAuthority, authority.Id, models.ActionCreate); err != nil {
 		panic(err)
@@ -213,7 +237,7 @@ func (c AppControllerWithValidation) PostCreateAuthority(appId int, email string
 func (c AppControllerWithValidation) PostDeleteAuthority(appId, authorityId int) revel.Result {
 	app := c.App
 
-	authority, err := models.GetAuthority(c.Txn, authorityId)
+	authority, err := models.GetAuthority(Dbm, authorityId)
 	if err != nil {
 		panic(err)
 	}
@@ -223,7 +247,10 @@ func (c AppControllerWithValidation) PostDeleteAuthority(appId, authorityId int)
 		return c.Redirect(routes.AppControllerWithValidation.GetApp(appId))
 	}
 
-	if err := app.DeleteAuthority(c.Txn, c.GoogleService, authority); err != nil {
+	err = Transact(func(txn gorp.SqlExecutor) error {
+		return app.DeleteAuthority(txn, c.GoogleService, authority)
+	})
+	if err != nil {
 		panic(err)
 	}
 
@@ -244,7 +271,7 @@ func (c *AppControllerWithValidation) CheckNotFound() revel.Result {
 	if err != nil {
 		panic(err)
 	}
-	app, err := models.GetApp(c.Txn, appId)
+	app, err := models.GetApp(Dbm, appId)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return c.NotFound("NotFound")

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -174,10 +174,7 @@ func (c AppControllerWithValidation) PostCreateBundle(appId int, bundle models.B
 		bundle.FileName = c.Params.Files["file"][0].Filename
 	}
 
-	err := Transact(func(txn gorp.SqlExecutor) error {
-		return c.App.CreateBundle(txn, c.GoogleService, Conf.AaptPath, &bundle)
-	})
-	if err != nil {
+	if err := c.App.CreateBundle(Dbm, c.GoogleService, Conf.AaptPath, &bundle); err != nil {
 		if aperr, ok := err.(*models.ApkParseError); ok {
 			c.Flash.Error(aperr.Error())
 			return c.Redirect(routes.AppControllerWithValidation.GetCreateBundle(appId))

--- a/app/controllers/gorp.go
+++ b/app/controllers/gorp.go
@@ -88,34 +88,3 @@ func Transact(f func(gorp.SqlExecutor) error) error {
 	txn = nil
 	return nil
 }
-
-func (c *GorpController) Begin() revel.Result {
-	txn, err := Dbm.Begin()
-	if err != nil {
-		panic(err)
-	}
-	c.Txn = txn
-	return nil
-}
-
-func (c *GorpController) Commit() revel.Result {
-	if c.Txn == nil {
-		return nil
-	}
-	if err := c.Txn.Commit(); err != nil && err != sql.ErrTxDone {
-		panic(err)
-	}
-	c.Txn = nil
-	return nil
-}
-
-func (c *GorpController) Rollback() revel.Result {
-	if c.Txn == nil {
-		return nil
-	}
-	if err := c.Txn.Rollback(); err != nil && err != sql.ErrTxDone {
-		panic(err)
-	}
-	c.Txn = nil
-	return nil
-}

--- a/app/controllers/gorp.go
+++ b/app/controllers/gorp.go
@@ -67,7 +67,7 @@ func Transact(f func(gorp.SqlExecutor) error) error {
 	if err != nil {
 		return err
 	}
-	go func() {
+	defer func() {
 		if txn == nil {
 			return
 		}

--- a/app/controllers/init.go
+++ b/app/controllers/init.go
@@ -31,9 +31,6 @@ func init() {
 
 	// gorp
 	revel.OnAppStart(InitDB)
-	revel.InterceptMethod((*GorpController).Begin, revel.BEFORE)
-	revel.InterceptMethod((*GorpController).Commit, revel.AFTER)
-	revel.InterceptMethod((*GorpController).Rollback, revel.FINALLY)
 
 	// service account
 	revel.InterceptMethod((*AlphaWingController).InitGoogleService, revel.BEFORE)

--- a/app/models/audit.go
+++ b/app/models/audit.go
@@ -47,25 +47,25 @@ func (audit *Audit) Validate(v *revel.Validation) {
 	v.Required(audit.Action)
 }
 
-func (audit *Audit) Save(txn *gorp.Transaction) error {
+func (audit *Audit) Save(txn gorp.SqlExecutor) error {
 	return txn.Insert(audit)
 }
 
-func (audit *Audit) Update(txn *gorp.Transaction) error {
+func (audit *Audit) Update(txn gorp.SqlExecutor) error {
 	_, err := txn.Update(audit)
 	return err
 }
 
-func (audit *Audit) Delete(txn *gorp.Transaction) error {
+func (audit *Audit) Delete(txn gorp.SqlExecutor) error {
 	_, err := txn.Delete(audit)
 	return err
 }
 
-func CreateAudit(txn *gorp.Transaction, audit *Audit) error {
+func CreateAudit(txn gorp.SqlExecutor, audit *Audit) error {
 	return txn.Insert(audit)
 }
 
-func GetAudit(txn *gorp.Transaction, id int) (*Audit, error) {
+func GetAudit(txn gorp.SqlExecutor, id int) (*Audit, error) {
 	audit, err := txn.Get(Audit{}, id)
 	if err != nil {
 		return nil, err

--- a/app/models/authority.go
+++ b/app/models/authority.go
@@ -26,16 +26,16 @@ func (authority *Authority) PreUpdate(s gorp.SqlExecutor) error {
 	return nil
 }
 
-func (authority *Authority) Save(txn *gorp.Transaction) error {
+func (authority *Authority) Save(txn gorp.SqlExecutor) error {
 	return txn.Insert(authority)
 }
 
-func (authority *Authority) DeleteFromDB(txn *gorp.Transaction) error {
+func (authority *Authority) DeleteFromDB(txn gorp.SqlExecutor) error {
 	_, err := txn.Delete(authority)
 	return err
 }
 
-func GetAuthority(txn *gorp.Transaction, id int) (*Authority, error) {
+func GetAuthority(txn gorp.SqlExecutor, id int) (*Authority, error) {
 	authority, err := txn.Get(Authority{}, id)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func GetAuthority(txn *gorp.Transaction, id int) (*Authority, error) {
 	return authority.(*Authority), nil
 }
 
-func IsExistAuthorityForEmail(txn *gorp.Transaction, email string) (bool, error) {
+func IsExistAuthorityForEmail(txn gorp.SqlExecutor, email string) (bool, error) {
 	count, err := txn.SelectInt("SELECT COUNT(id) FROM authority WHERE email = ?", email)
 	if err != nil {
 		return false, err

--- a/app/models/bundle.go
+++ b/app/models/bundle.go
@@ -50,7 +50,7 @@ func (bundle *Bundle) JsonResponse(ub UriBuilder) (*BundleJsonResponse, error) {
 	}, nil
 }
 
-func (bundle *Bundle) App(txn *gorp.Transaction) (*App, error) {
+func (bundle *Bundle) App(txn gorp.SqlExecutor) (*App, error) {
 	app, err := txn.Get(App{}, bundle.AppId)
 	if err != nil {
 		return nil, err
@@ -70,11 +70,11 @@ func (bundle *Bundle) PreUpdate(s gorp.SqlExecutor) error {
 	return nil
 }
 
-func (bundle *Bundle) Save(txn *gorp.Transaction) error {
+func (bundle *Bundle) Save(txn gorp.SqlExecutor) error {
 	return txn.Insert(bundle)
 }
 
-func (bundle *Bundle) Update(txn *gorp.Transaction) error {
+func (bundle *Bundle) Update(txn gorp.SqlExecutor) error {
 	current, err := GetBundle(txn, bundle.Id)
 	if err != nil {
 		return err
@@ -86,7 +86,7 @@ func (bundle *Bundle) Update(txn *gorp.Transaction) error {
 	return err
 }
 
-func (bundle *Bundle) DeleteFromDB(txn *gorp.Transaction) error {
+func (bundle *Bundle) DeleteFromDB(txn gorp.SqlExecutor) error {
 	_, err := txn.Delete(bundle)
 	return err
 }
@@ -95,7 +95,7 @@ func (bundle *Bundle) DeleteFromGoogleDrive(s *GoogleService) error {
 	return s.DeleteFile(bundle.FileId)
 }
 
-func (bundle *Bundle) Delete(txn *gorp.Transaction, s *GoogleService) error {
+func (bundle *Bundle) Delete(txn gorp.SqlExecutor, s *GoogleService) error {
 	if err := bundle.DeleteFromDB(txn); err != nil {
 		return err
 	}
@@ -105,11 +105,11 @@ func (bundle *Bundle) Delete(txn *gorp.Transaction, s *GoogleService) error {
 	return nil
 }
 
-func CreateBundle(txn *gorp.Transaction, bundle *Bundle) error {
+func CreateBundle(txn gorp.SqlExecutor, bundle *Bundle) error {
 	return txn.Insert(bundle)
 }
 
-func GetBundle(txn *gorp.Transaction, id int) (*Bundle, error) {
+func GetBundle(txn gorp.SqlExecutor, id int) (*Bundle, error) {
 	bundle, err := txn.Get(Bundle{}, id)
 	if err != nil {
 		return nil, err

--- a/app/models/bundle.go
+++ b/app/models/bundle.go
@@ -81,6 +81,9 @@ func (bundle *Bundle) Update(txn gorp.SqlExecutor) error {
 	}
 
 	current.Description = bundle.Description
+	if bundle.FileId != "" {
+		current.FileId = bundle.FileId
+	}
 
 	_, err = txn.Update(current)
 	return err

--- a/app/models/user.go
+++ b/app/models/user.go
@@ -30,25 +30,25 @@ func (user *User) Validate(v *revel.Validation) {
 	v.Required(user.Email)
 }
 
-func (user *User) Save(txn *gorp.Transaction) error {
+func (user *User) Save(txn gorp.SqlExecutor) error {
 	return txn.Insert(user)
 }
 
-func (user *User) Update(txn *gorp.Transaction) error {
+func (user *User) Update(txn gorp.SqlExecutor) error {
 	_, err := txn.Update(user)
 	return err
 }
 
-func (user *User) Delete(txn *gorp.Transaction) error {
+func (user *User) Delete(txn gorp.SqlExecutor) error {
 	_, err := txn.Delete(user)
 	return err
 }
 
-func CreateUser(txn *gorp.Transaction, user *User) error {
+func CreateUser(txn gorp.SqlExecutor, user *User) error {
 	return txn.Insert(user)
 }
 
-func FindOrCreateUser(txn *gorp.Transaction, email string) (*User, error) {
+func FindOrCreateUser(txn gorp.SqlExecutor, email string) (*User, error) {
 	user, err := GetUserFromEmail(txn, email)
 	if err == sql.ErrNoRows {
 		user = &User{
@@ -64,7 +64,7 @@ func FindOrCreateUser(txn *gorp.Transaction, email string) (*User, error) {
 	return user, nil
 }
 
-func GetUser(txn *gorp.Transaction, id int) (*User, error) {
+func GetUser(txn gorp.SqlExecutor, id int) (*User, error) {
 	user, err := txn.Get(User{}, id)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func GetUser(txn *gorp.Transaction, id int) (*User, error) {
 	return user.(*User), nil
 }
 
-func GetUserFromEmail(txn *gorp.Transaction, email string) (*User, error) {
+func GetUserFromEmail(txn gorp.SqlExecutor, email string) (*User, error) {
 	var user User
 	err := txn.SelectOne(&user, "SELECT * FROM user WHERE email = ?", email)
 	if err != nil {


### PR DESCRIPTION
https://github.com/kayac/alphawing/issues/11 の対応です。

- `*gorp.Transaction` -> `gorp.SqlExecutor` に置換
  - トランザクション内でもトランザクション外でも同様に扱えるよう、interfaceに置き換えました
- `c.Txn`を削除
  - 参照しか行わない部分は`Dbm`に置き換えました
  - 更新がある部分は`Dbm.Begin()`でトランザクションを開始します