### PR TITLE
削除中はgoogle driveの404を無視

### DIFF
--- a/app/models/bundle.go
+++ b/app/models/bundle.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"time"
@@ -210,17 +211,20 @@ func (bundle *Bundle) DeleteFromDB(txn gorp.SqlExecutor) error {
 }
 
 func (bundle *Bundle) DeleteFromGoogleDrive(s *GoogleService) error {
+	if bundle.FileId == "" {
+		return nil
+	}
 	return s.DeleteFile(bundle.FileId)
 }
 
 func (bundle *Bundle) Delete(txn gorp.SqlExecutor, s *GoogleService) error {
-	if err := bundle.DeleteFromDB(txn); err != nil {
-		return err
-	}
 	if err := bundle.DeleteFromGoogleDrive(s); err != nil {
-		return err
+		code, _, _ := ParseGoogleApiError(err)
+		if code != http.StatusNotFound {
+			return err
+		}
 	}
-	return nil
+	return bundle.DeleteFromDB(txn)
 }
 
 func CreateBundle(txn gorp.SqlExecutor, bundle *Bundle) error {

--- a/app/models/googleservice.go
+++ b/app/models/googleservice.go
@@ -11,6 +11,7 @@ import (
 	"code.google.com/p/goauth2/oauth"
 	"code.google.com/p/goauth2/oauth/jwt"
 	"code.google.com/p/google-api-go-client/drive/v2"
+	"code.google.com/p/google-api-go-client/googleapi"
 	"code.google.com/p/google-api-go-client/oauth2/v2"
 )
 
@@ -225,6 +226,10 @@ func (s *GoogleService) GetCapacityInfo() (*CapacityInfo, error) {
 }
 
 func ParseGoogleApiError(apiErr error) (int, string, error) {
+	if googleErr, ok := apiErr.(*googleapi.Error); ok {
+		return googleErr.Code, googleErr.Message, nil
+	}
+
 	reg, err := regexp.Compile(`googleapi: got HTTP response code (\d+) and error reading body: (.+)`)
 	if err != nil {
 		return 0, "", err


### PR DESCRIPTION
何らかのエラーでalphawingのDBにはファイルが残っているけどGoogle Drive上からは削除されてしまった場合、
GoogleDriveが404をかえしてエラーになるので通常の手段ではBundleを削除する手段が無くなってしまいます。

Google Driveから削除されてしまったら基本的に復旧できないので、404を無視してalphawing上から削除してしまいます。