### PR TITLE
revision管理用のテーブルを追加

### DIFF
--- a/app/controllers/gorp.go
+++ b/app/controllers/gorp.go
@@ -25,9 +25,15 @@ func InitDB() {
 	appTableMap := Dbm.AddTableWithName(models.App{}, "app")
 	appTableMap.SetKeys(true, "Id")
 	appTableMap.ColMap("ApiToken").SetUnique(true)
+	appTableMap.ColMap("FileId").SetUnique(true)
 
 	bundleTableMap := Dbm.AddTableWithName(models.Bundle{}, "bundle")
 	bundleTableMap.SetKeys(true, "Id")
+	bundleTableMap.ColMap("FileId").SetUnique(true)
+
+	revisionTableMap := Dbm.AddTableWithName(models.Revision{}, "revision")
+	revisionTableMap.SetKeys(true, "Id")
+	revisionTableMap.SetUniqueTogether("app_id", "platform_type", "bundle_version")
 
 	authorityTableMap := Dbm.AddTableWithName(models.Authority{}, "authority")
 	authorityTableMap.SetKeys(true, "Id")
@@ -39,7 +45,10 @@ func InitDB() {
 	auditTableMap.SetKeys(true, "Id")
 
 	Dbm.TraceOn("[gorp]", revel.INFO)
-	Dbm.CreateTablesIfNotExists()
+	err := Dbm.CreateTablesIfNotExists()
+	if err != nil {
+		panic(err)
+	}
 }
 
 func getDbm() *gorp.DbMap {

--- a/app/models/app.go
+++ b/app/models/app.go
@@ -77,10 +77,11 @@ func (app *App) Authorities(txn gorp.SqlExecutor) ([]*Authority, error) {
 	return authorities, nil
 }
 
-func (app *App) GetMaxRevisionByBundleVersion(txn gorp.SqlExecutor, bundleVersion string) (int, error) {
+func (app *App) GetMaxRevisionByBundleVersion(txn gorp.SqlExecutor, platformType BundlePlatformType, bundleVersion string) (int, error) {
 	revision, err := txn.SelectInt(
-		"SELECT IFNULL(MAX(revision), 0) FROM bundle WHERE app_id = ? AND bundle_version = ?",
+		"SELECT IFNULL(MAX(revision), 0) FROM bundle WHERE app_id = ? AND platform_type = ? AND bundle_version = ?",
 		app.Id,
+		platformType,
 		bundleVersion,
 	)
 	return int(revision), err
@@ -227,7 +228,7 @@ func (app *App) CreateBundle(dbm *gorp.DbMap, s *GoogleService, bundle *Bundle) 
 
 	// increment revision number & save application information
 	err = Transact(dbm, func(txn gorp.SqlExecutor) error {
-		maxRevision, err := app.GetMaxRevisionByBundleVersion(txn, bundleInfo.Version)
+		maxRevision, err := app.GetMaxRevisionByBundleVersion(txn, bundle.PlatformType, bundleInfo.Version)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
GoogleDriveにアップロードする直前にFileIdが空のBundleを追加してrevisionをあげていましたが、
以下の問題があります

- Upload中にFileIdが空っぽのBundleが他のユーザに見えてしまう
- GoogleDriveへのアップロードが失敗すると、FileIdが空のまま残ってしまう
- Bundleを削除してしまうと同じrevisionが再利用されてしまう

revisionを別テーブルに分離しbundleとは別で管理することにより、これらの問題を解消します。