### PR TITLE
[WIP]storage interface

### DIFF
--- a/app/controllers/api.go
+++ b/app/controllers/api.go
@@ -92,7 +92,7 @@ func (c ApiController) PostUploadBundle(token string, description string, file *
 		File:         file,
 	}
 
-	if err := app.CreateBundle(Dbm, c.GoogleService, bundle); err != nil {
+	if err := app.CreateBundle(Dbm, bundle); err != nil {
 		if bperr, ok := err.(*models.BundleParseError); ok {
 			c.Response.Status = http.StatusInternalServerError
 			return c.RenderJson(c.NewJsonResponseUploadBundle(c.Response.Status, []string{bperr.Error()}, nil))
@@ -139,7 +139,7 @@ func (c ApiController) PostDeleteBundle(token string, file_id string) revel.Resu
 	}
 
 	err = Transact(func(txn gorp.SqlExecutor) error {
-		return bundle.Delete(txn, c.GoogleService)
+		return bundle.Delete(txn)
 	})
 	if err != nil {
 		c.Response.Status = http.StatusInternalServerError

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -42,9 +42,11 @@ func (c AppController) injectServiceToApp(app *models.App) error {
 		return err
 	}
 
-	app.Storage = storage.GoogleDrive{
-		Service: service,
+	s, err := storage.NewGoogleDrive(service, app.FileId)
+	if err != nil {
+		return err
 	}
+	app.Storage = s
 	app.Permission = permission.GoogleDrive{
 		Service: service,
 	}

--- a/app/controllers/app.go
+++ b/app/controllers/app.go
@@ -34,7 +34,7 @@ func (c AppController) GetCreateApp() revel.Result {
 		PrivateKey:  Conf.ServiceAccountPrivateKey,
 	}
 
-	token, err := models.GetServiceAccountToken(config)
+	token, err := googleservice.GetServiceAccountToken(config)
 	if err != nil {
 		panic(err)
 	}

--- a/app/controllers/bundle.go
+++ b/app/controllers/bundle.go
@@ -101,8 +101,6 @@ func (c BundleControllerWithValidation) GetDownloadApk(bundleId int) revel.Resul
 		panic(err)
 	}
 
-	fmt.Printf("%+v", resp)
-
 	err = c.createAudit(models.ResourceBundle, bundleId, models.ActionDownload)
 	if err != nil {
 		panic(err)

--- a/app/controllers/bundle.go
+++ b/app/controllers/bundle.go
@@ -101,6 +101,8 @@ func (c BundleControllerWithValidation) GetDownloadApk(bundleId int) revel.Resul
 		panic(err)
 	}
 
+	fmt.Printf("%+v", resp)
+
 	err = c.createAudit(models.ResourceBundle, bundleId, models.ActionDownload)
 	if err != nil {
 		panic(err)

--- a/app/controllers/bundle.go
+++ b/app/controllers/bundle.go
@@ -96,7 +96,7 @@ func (c BundleControllerWithValidation) GetDownloadBundle(bundleId int) revel.Re
 }
 
 func (c BundleControllerWithValidation) GetDownloadApk(bundleId int) revel.Result {
-	resp, storageFile, err := c.Bundle.DownloadFile()
+	r, storageFile, err := c.Bundle.DownloadFile()
 	if err != nil {
 		panic(err)
 	}
@@ -107,7 +107,7 @@ func (c BundleControllerWithValidation) GetDownloadApk(bundleId int) revel.Resul
 	}
 
 	c.Response.ContentType = "application/vnd.android.package-archive"
-	return c.RenderBinary(resp.Body, storageFile.Filename, revel.Attachment, storageFile.Modtime)
+	return c.RenderBinary(r, storageFile.Filename, revel.Attachment, storageFile.Modtime)
 }
 
 func (c *BundleControllerWithValidation) CheckNotFound() revel.Result {

--- a/app/controllers/bundle.go
+++ b/app/controllers/bundle.go
@@ -96,7 +96,7 @@ func (c BundleControllerWithValidation) GetDownloadBundle(bundleId int) revel.Re
 }
 
 func (c BundleControllerWithValidation) GetDownloadApk(bundleId int) revel.Result {
-	resp, storageFile, err := bundle.DownloadFile()
+	resp, storageFile, err := c.Bundle.DownloadFile()
 	if err != nil {
 		panic(err)
 	}
@@ -107,7 +107,7 @@ func (c BundleControllerWithValidation) GetDownloadApk(bundleId int) revel.Resul
 	}
 
 	c.Response.ContentType = "application/vnd.android.package-archive"
-	return c.RenderBinary(resp.Body, file.OriginalFilename, revel.Attachment, storageFile.Modtime)
+	return c.RenderBinary(resp.Body, storageFile.Filename, revel.Attachment, storageFile.Modtime)
 }
 
 func (c *BundleControllerWithValidation) CheckNotFound() revel.Result {
@@ -131,7 +131,7 @@ func (c *BundleControllerWithValidation) CheckNotFound() revel.Result {
 		PrivateKey:  Conf.ServiceAccountPrivateKey,
 	}
 
-	token, err := models.GetServiceAccountToken(config)
+	token, err := googleservice.GetServiceAccountToken(config)
 	if err != nil {
 		panic(err)
 	}

--- a/app/googleservice/googleservice.go
+++ b/app/googleservice/googleservice.go
@@ -2,13 +2,91 @@ package googleservice
 
 import (
 	"errors"
+	"net/http"
+	"strings"
 
+	"google.golang.org/api/oauth2/v1"
+
+	"code.google.com/p/goauth2/oauth"
+	"code.google.com/p/goauth2/oauth/jwt"
 	"code.google.com/p/google-api-go-client/drive/v2"
 )
 
 type GoogleService struct {
-	FilesService      *drive.FilesService
-	PermissionService *drive.PermissionService
+	AccessToken        string
+	Client             *http.Client
+	OAuth2Service      *oauth2.Service
+	DriveService       *drive.Service
+	AboutService       *drive.AboutService
+	FilesService       *drive.FilesService
+	PermissionsService *drive.PermissionsService
+}
+
+type Config struct {
+	ClientId     string
+	CliendSecret string
+	CallbackUrl  string
+	Scope        []string
+}
+
+func createOAuthClient(token *oauth.Token) *http.Client {
+	transport := &oauth.Transport{
+		Token: token,
+	}
+	return transport.Client()
+}
+
+func (c *Config) NewOAuthConfig(tokenCache oauth.Cache) *oauth.Config {
+	return &oauth.Config{
+		ClientId:     config.ClientId,
+		ClientSecret: config.ClientSecret,
+		AuthURL:      "https://accounts.google.com/o/oauth2/auth",
+		TokenURL:     "https://accounts.google.com/o/oauth2/token",
+		RedirectURL:  config.CallbackUrl,
+		Scope:        strings.Join(config.Scope, " "),
+		TokenCache:   tokenCache,
+	}
+}
+
+type ServiceAccountConfig struct {
+	ClientEmail string
+	PrivateKey  string
+}
+
+func GetServiceAccountToken(config *ServiceAccountConfig) (*oauth.Token, error) {
+	token := jwt.NewToken(config.ClientEmail, strings.Join([]string{drive.DriveScope}, " "), []byte(config.PrivateKey))
+
+	client := &http.Client{}
+	oauthToken, err := token.Assert(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return oauthToken, nil
+}
+
+func NewGoogleService(token *oauth.Token) (*GoogleService, error) {
+	client := createOAuthClient(token)
+
+	oauth2Service, err := oauth2.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	driveService, err := drive.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GoogleService{
+		AccessToken:        token.AccessToken,
+		Client:             client,
+		OAuth2Service:      oauth2Service,
+		DriveService:       driveService,
+		AboutService:       drive.NewAboutService(driveService),
+		FilesService:       drive.NewFilesService(driveService),
+		PermissionsService: drive.NewPermissionsService(driveService),
+	}, nil
 }
 
 func (s *GoogleService) CreateFolder(folderName string) (*drive.File, error) {

--- a/app/googleservice/googleservice.go
+++ b/app/googleservice/googleservice.go
@@ -1,7 +1,61 @@
 package googleservice
 
-import "code.google.com/p/google-api-go-client/drive/v2"
+import (
+	"errors"
+
+	"code.google.com/p/google-api-go-client/drive/v2"
+)
 
 type GoogleService struct {
-	FilesService *drive.FilesService
+	FilesService      *drive.FilesService
+	PermissionService *drive.PermissionService
+}
+
+func (s *GoogleService) CreateFolder(folderName string) (*drive.File, error) {
+	driveFolder := &drive.File{
+		Title:    folderName,
+		MimeType: "application/vnd.google-apps.folder",
+	}
+	return s.FilesService.Insert(driveFolder).Do()
+}
+
+func (s *GoogleService) CreateUserPermission(email string, role string) *drive.Permission {
+	return &drive.Permission{
+		Role:  role,
+		Type:  "user",
+		Value: email,
+	}
+}
+
+func (s *GoogleService) InsertPermission(fileId string, permission *drive.Permission) (*drive.Permission, error) {
+	return s.PermissionsService.Insert(fileId, permission).Do()
+}
+
+func (s *GoogleService) GetPermissionList(fileId string) (*drive.PermissionList, error) {
+	return s.PermissionsService.List(fileId).Do()
+}
+
+func (s *GoogleService) DeletePermission(fileId string, permissionId string) error {
+	return s.PermissionsService.Delete(fileId, permissionId).Do()
+}
+
+func (s *GoogleService) GetPermissionId(fileId string, email string) (string, error) {
+	permList, err := s.GetPermissionList(fileId)
+	if err != nil {
+		return "", err
+	}
+
+	var permId string
+	for _, perm := range permList.Items {
+		if perm.EmailAddress == email {
+			permId = perm.Id
+			break
+		}
+	}
+
+	if !permId {
+		return "", errors.New("Not found email in folder")
+	}
+
+	return permId, nil
 }

--- a/app/googleservice/googleservice.go
+++ b/app/googleservice/googleservice.go
@@ -24,7 +24,7 @@ type GoogleService struct {
 
 type Config struct {
 	ClientId     string
-	CliendSecret string
+	ClientSecret string
 	CallbackUrl  string
 	Scope        []string
 }
@@ -38,12 +38,12 @@ func createOAuthClient(token *oauth.Token) *http.Client {
 
 func (c *Config) NewOAuthConfig(tokenCache oauth.Cache) *oauth.Config {
 	return &oauth.Config{
-		ClientId:     config.ClientId,
-		ClientSecret: config.ClientSecret,
+		ClientId:     c.ClientId,
+		ClientSecret: c.ClientSecret,
 		AuthURL:      "https://accounts.google.com/o/oauth2/auth",
 		TokenURL:     "https://accounts.google.com/o/oauth2/token",
-		RedirectURL:  config.CallbackUrl,
-		Scope:        strings.Join(config.Scope, " "),
+		RedirectURL:  c.CallbackUrl,
+		Scope:        strings.Join(c.Scope, " "),
 		TokenCache:   tokenCache,
 	}
 }
@@ -131,7 +131,7 @@ func (s *GoogleService) GetPermissionId(fileId string, email string) (string, er
 		}
 	}
 
-	if !permId {
+	if permId == "" {
 		return "", errors.New("Not found email in folder")
 	}
 

--- a/app/googleservice/googleservice.go
+++ b/app/googleservice/googleservice.go
@@ -1,0 +1,7 @@
+package googleservice
+
+import "code.google.com/p/google-api-go-client/drive/v2"
+
+type GoogleService struct {
+	FilesService *drive.FilesService
+}

--- a/app/models/app.go
+++ b/app/models/app.go
@@ -144,7 +144,10 @@ func (app *App) DeleteFromDB(txn gorp.SqlExecutor) error {
 }
 
 func (app *App) DeleteFromGoogleDrive(s *GoogleService) error {
-	return s.DeleteFile(app.FileId)
+	gd := &storage.GoogleDrive{
+		Service: &googleservice.GoogleService{FilesService: s.FilesService},
+	}
+	return gd.Delete(storage.FileIdentifier{FileId: app.FileId})
 }
 
 func (app *App) Delete(txn gorp.SqlExecutor, s *GoogleService) error {

--- a/app/models/app.go
+++ b/app/models/app.go
@@ -275,6 +275,7 @@ func (app *App) UpdateFileTitle(name string) error {
 }
 
 func CreateApp(txn gorp.SqlExecutor, app *App) error {
+	fmt.Printf("%+v", app)
 	groupId, err := app.Permission.CreateGroup(app.Title)
 	if err != nil {
 		return err

--- a/app/models/app.go
+++ b/app/models/app.go
@@ -271,7 +271,7 @@ func (app *App) CreateAuthority(txn gorp.SqlExecutor, authority *Authority) erro
 }
 
 func (app *App) UpdateFileTitle(name string) error {
-	return app.Storage.ChangeFilename(name)
+	return app.Storage.ChangeFilename(app.FileId, name)
 }
 
 func CreateApp(txn gorp.SqlExecutor, app *App) error {

--- a/app/models/bundle.go
+++ b/app/models/bundle.go
@@ -247,8 +247,8 @@ func (bundle *Bundle) Delete(txn gorp.SqlExecutor) error {
 	return bundle.DeleteFromDB(txn)
 }
 
-func (bundle *Bundle) DownloadFile() (*http.Response, error) {
-	return bundle.Storage.GetFile(bundle.FileId)
+func (bundle *Bundle) DownloadFile() (*http.Response, storage.StorageFile, error) {
+	return bundle.Storage.DownloadFile(bundle.FileId)
 }
 
 func CreateBundle(txn gorp.SqlExecutor, bundle *Bundle) error {

--- a/app/models/bundle.go
+++ b/app/models/bundle.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/coopernurse/gorp"
+	"github.com/kayac/alphawing/app/googleservice"
+	"github.com/kayac/alphawing/app/storage"
 )
 
 type BundlePlatformType int
@@ -230,7 +232,10 @@ func (bundle *Bundle) DeleteFromGoogleDrive(s *GoogleService) error {
 	if bundle.FileId == "" {
 		return nil
 	}
-	return s.DeleteFile(bundle.FileId)
+	gd := &storage.GoogleDrive{
+		Service: &googleservice.GoogleService{FilesService: s.FilesService},
+	}
+	return gd.Delete(storage.FileIdentifier{FileId: bundle.FileId})
 }
 
 func (bundle *Bundle) Delete(txn gorp.SqlExecutor, s *GoogleService) error {

--- a/app/models/bundle.go
+++ b/app/models/bundle.go
@@ -247,7 +247,7 @@ func (bundle *Bundle) Delete(txn gorp.SqlExecutor) error {
 	return bundle.DeleteFromDB(txn)
 }
 
-func (bundle *Bundle) DownloadFile() (*http.Response, storage.StorageFile, error) {
+func (bundle *Bundle) DownloadFile() (io.Reader, storage.StorageFile, error) {
 	return bundle.Storage.DownloadFile(bundle.FileId)
 }
 

--- a/app/models/googleservice.go
+++ b/app/models/googleservice.go
@@ -3,9 +3,13 @@ package models
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
+	"strings"
 
+	"code.google.com/p/goauth2/oauth"
+	"code.google.com/p/goauth2/oauth/jwt"
 	"code.google.com/p/google-api-go-client/drive/v2"
 	"code.google.com/p/google-api-go-client/googleapi"
 	"code.google.com/p/google-api-go-client/oauth2/v2"
@@ -40,12 +44,162 @@ type CapacityInfo struct {
 	PercentageRemained string
 }
 
+func CreateOAuthConfig(config *WebApplicationConfig, tokenCache oauth.Cache) *oauth.Config {
+	return &oauth.Config{
+		ClientId:     config.ClientId,
+		ClientSecret: config.ClientSecret,
+		AuthURL:      "https://accounts.google.com/o/oauth2/auth",
+		TokenURL:     "https://accounts.google.com/o/oauth2/token",
+		RedirectURL:  config.CallbackUrl,
+		Scope:        strings.Join(config.Scope, " "),
+		TokenCache:   tokenCache,
+	}
+}
+
+func GetServiceAccountToken(config *ServiceAccountConfig) (*oauth.Token, error) {
+	token := jwt.NewToken(config.ClientEmail, strings.Join(config.Scope, " "), []byte(config.PrivateKey))
+
+	client := &http.Client{}
+	oauthToken, err := token.Assert(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return oauthToken, nil
+}
+
+func createOAuthClient(token *oauth.Token) *http.Client {
+	transport := &oauth.Transport{
+		Token: token,
+	}
+	return transport.Client()
+}
+
+func NewGoogleService(token *oauth.Token) (*GoogleService, error) {
+	client := createOAuthClient(token)
+
+	oauth2Service, err := oauth2.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	driveService, err := drive.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GoogleService{
+		AccessToken:        token.AccessToken,
+		Client:             client,
+		OAuth2Service:      oauth2Service,
+		DriveService:       driveService,
+		AboutService:       drive.NewAboutService(driveService),
+		FilesService:       drive.NewFilesService(driveService),
+		PermissionsService: drive.NewPermissionsService(driveService),
+	}, nil
+}
+
 func (s *GoogleService) GetUserInfo() (*oauth2.Userinfoplus, error) {
 	return s.OAuth2Service.Userinfo.Get().Do()
 }
 
 func (s *GoogleService) GetTokenInfo() (*oauth2.Tokeninfo, error) {
 	return s.OAuth2Service.Tokeninfo().Access_token(s.AccessToken).Do()
+}
+
+func (s *GoogleService) CreateFolder(folderName string) (*drive.File, error) {
+	driveFolder := &drive.File{
+		Title:    folderName,
+		MimeType: "application/vnd.google-apps.folder",
+	}
+	return s.FilesService.Insert(driveFolder).Do()
+}
+
+func (s *GoogleService) InsertFile(file *os.File, filename string, parent *drive.ParentReference) (*drive.File, error) {
+	driveFile := &drive.File{
+		Title:   filename,
+		Parents: []*drive.ParentReference{parent},
+	}
+	return s.FilesService.Insert(driveFile).Media(file).Do()
+}
+
+func (s *GoogleService) GetFile(fileId string) (*drive.File, error) {
+	return s.FilesService.Get(fileId).Do()
+}
+
+func (s *GoogleService) DownloadFile(fileId string) (*http.Response, *drive.File, error) {
+	file, err := s.GetFile(fileId)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := s.Client.Get(file.DownloadUrl)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, file, nil
+}
+
+func (s *GoogleService) GetFileList() (*drive.FileList, error) {
+	return s.FilesService.List().Do()
+}
+
+func (s *GoogleService) GetSharedFileList(ownerEmail string) (*drive.FileList, error) {
+	q := fmt.Sprintf("'%s' in owners and sharedWithMe = true", ownerEmail)
+	return s.FilesService.List().Q(q).Do()
+}
+
+func (s *GoogleService) UpdateFileTitle(fileId string, title string) error {
+	file, err := s.GetFile(fileId)
+	if err != nil {
+		return err
+	}
+	file.Title = title
+	_, err = s.FilesService.Update(fileId, file).Do()
+	return err
+}
+
+func (s *GoogleService) DeleteFile(fileId string) error {
+	return s.FilesService.Delete(fileId).Do()
+}
+
+func (s *GoogleService) DeleteAllFiles() error {
+	fileList, err := s.GetFileList()
+	if err != nil {
+		return err
+	}
+
+	for _, file := range fileList.Items {
+		err = s.DeleteFile(file.Id)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *GoogleService) CreateUserPermission(email string, role string) *drive.Permission {
+	return &drive.Permission{
+		Role:  role,
+		Type:  "user",
+		Value: email,
+	}
+}
+
+func (s *GoogleService) InsertPermission(fileId string, permission *drive.Permission) (*drive.Permission, error) {
+	return s.PermissionsService.Insert(fileId, permission).Do()
+}
+
+func (s *GoogleService) GetPermissionList(fileId string) (*drive.PermissionList, error) {
+	return s.PermissionsService.List(fileId).Do()
+}
+
+func (sa *GoogleService) UpdatePermission(fileId string, permissionId string, permission *drive.Permission) (*drive.Permission, error) {
+	return sa.PermissionsService.Update(fileId, permissionId, permission).Do()
+}
+
+func (s *GoogleService) DeletePermission(fileId string, permissionId string) error {
+	return s.PermissionsService.Delete(fileId, permissionId).Do()
 }
 
 func (s *GoogleService) GetAbout() (*drive.About, error) {

--- a/app/models/googleservice.go
+++ b/app/models/googleservice.go
@@ -149,26 +149,6 @@ func (s *GoogleService) UpdateFileTitle(fileId string, title string) error {
 	return err
 }
 
-func (s *GoogleService) DeleteFile(fileId string) error {
-	return s.FilesService.Delete(fileId).Do()
-}
-
-func (s *GoogleService) DeleteAllFiles() error {
-	fileList, err := s.GetFileList()
-	if err != nil {
-		return err
-	}
-
-	for _, file := range fileList.Items {
-		err = s.DeleteFile(file.Id)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (s *GoogleService) CreateUserPermission(email string, role string) *drive.Permission {
 	return &drive.Permission{
 		Role:  role,

--- a/app/models/googleservice.go
+++ b/app/models/googleservice.go
@@ -5,10 +5,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
-	"strings"
 
-	"code.google.com/p/goauth2/oauth"
-	"code.google.com/p/goauth2/oauth/jwt"
 	"code.google.com/p/google-api-go-client/drive/v2"
 	"code.google.com/p/google-api-go-client/googleapi"
 	"code.google.com/p/google-api-go-client/oauth2/v2"
@@ -41,61 +38,6 @@ type CapacityInfo struct {
 	Used               string
 	Total              string
 	PercentageRemained string
-}
-
-func CreateOAuthConfig(config *WebApplicationConfig, tokenCache oauth.Cache) *oauth.Config {
-	return &oauth.Config{
-		ClientId:     config.ClientId,
-		ClientSecret: config.ClientSecret,
-		AuthURL:      "https://accounts.google.com/o/oauth2/auth",
-		TokenURL:     "https://accounts.google.com/o/oauth2/token",
-		RedirectURL:  config.CallbackUrl,
-		Scope:        strings.Join(config.Scope, " "),
-		TokenCache:   tokenCache,
-	}
-}
-
-func GetServiceAccountToken(config *ServiceAccountConfig) (*oauth.Token, error) {
-	token := jwt.NewToken(config.ClientEmail, strings.Join(config.Scope, " "), []byte(config.PrivateKey))
-
-	client := &http.Client{}
-	oauthToken, err := token.Assert(client)
-	if err != nil {
-		return nil, err
-	}
-
-	return oauthToken, nil
-}
-
-func createOAuthClient(token *oauth.Token) *http.Client {
-	transport := &oauth.Transport{
-		Token: token,
-	}
-	return transport.Client()
-}
-
-func NewGoogleService(token *oauth.Token) (*GoogleService, error) {
-	client := createOAuthClient(token)
-
-	oauth2Service, err := oauth2.New(client)
-	if err != nil {
-		return nil, err
-	}
-
-	driveService, err := drive.New(client)
-	if err != nil {
-		return nil, err
-	}
-
-	return &GoogleService{
-		AccessToken:        token.AccessToken,
-		Client:             client,
-		OAuth2Service:      oauth2Service,
-		DriveService:       driveService,
-		AboutService:       drive.NewAboutService(driveService),
-		FilesService:       drive.NewFilesService(driveService),
-		PermissionsService: drive.NewPermissionsService(driveService),
-	}, nil
 }
 
 func (s *GoogleService) GetUserInfo() (*oauth2.Userinfoplus, error) {

--- a/app/models/googleservice.go
+++ b/app/models/googleservice.go
@@ -106,34 +106,6 @@ func (s *GoogleService) GetTokenInfo() (*oauth2.Tokeninfo, error) {
 	return s.OAuth2Service.Tokeninfo().Access_token(s.AccessToken).Do()
 }
 
-func (s *GoogleService) CreateFolder(folderName string) (*drive.File, error) {
-	driveFolder := &drive.File{
-		Title:    folderName,
-		MimeType: "application/vnd.google-apps.folder",
-	}
-	return s.FilesService.Insert(driveFolder).Do()
-}
-
-func (s *GoogleService) CreateUserPermission(email string, role string) *drive.Permission {
-	return &drive.Permission{
-		Role:  role,
-		Type:  "user",
-		Value: email,
-	}
-}
-
-func (s *GoogleService) InsertPermission(fileId string, permission *drive.Permission) (*drive.Permission, error) {
-	return s.PermissionsService.Insert(fileId, permission).Do()
-}
-
-func (s *GoogleService) GetPermissionList(fileId string) (*drive.PermissionList, error) {
-	return s.PermissionsService.List(fileId).Do()
-}
-
-func (s *GoogleService) DeletePermission(fileId string, permissionId string) error {
-	return s.PermissionsService.Delete(fileId, permissionId).Do()
-}
-
 func (s *GoogleService) GetAbout() (*drive.About, error) {
 	return s.AboutService.Get().Do()
 }

--- a/app/models/googleservice.go
+++ b/app/models/googleservice.go
@@ -130,10 +130,6 @@ func (s *GoogleService) GetPermissionList(fileId string) (*drive.PermissionList,
 	return s.PermissionsService.List(fileId).Do()
 }
 
-func (sa *GoogleService) UpdatePermission(fileId string, permissionId string, permission *drive.Permission) (*drive.Permission, error) {
-	return sa.PermissionsService.Update(fileId, permissionId, permission).Do()
-}
-
 func (s *GoogleService) DeletePermission(fileId string, permissionId string) error {
 	return s.PermissionsService.Delete(fileId, permissionId).Do()
 }

--- a/app/models/googleservice.go
+++ b/app/models/googleservice.go
@@ -3,7 +3,6 @@ package models
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -113,14 +112,6 @@ func (s *GoogleService) CreateFolder(folderName string) (*drive.File, error) {
 		MimeType: "application/vnd.google-apps.folder",
 	}
 	return s.FilesService.Insert(driveFolder).Do()
-}
-
-func (s *GoogleService) InsertFile(file *os.File, filename string, parent *drive.ParentReference) (*drive.File, error) {
-	driveFile := &drive.File{
-		Title:   filename,
-		Parents: []*drive.ParentReference{parent},
-	}
-	return s.FilesService.Insert(driveFile).Media(file).Do()
 }
 
 func (s *GoogleService) GetFile(fileId string) (*drive.File, error) {

--- a/app/models/googleservice.go
+++ b/app/models/googleservice.go
@@ -114,41 +114,6 @@ func (s *GoogleService) CreateFolder(folderName string) (*drive.File, error) {
 	return s.FilesService.Insert(driveFolder).Do()
 }
 
-func (s *GoogleService) GetFile(fileId string) (*drive.File, error) {
-	return s.FilesService.Get(fileId).Do()
-}
-
-func (s *GoogleService) DownloadFile(fileId string) (*http.Response, *drive.File, error) {
-	file, err := s.GetFile(fileId)
-	if err != nil {
-		return nil, nil, err
-	}
-	resp, err := s.Client.Get(file.DownloadUrl)
-	if err != nil {
-		return nil, nil, err
-	}
-	return resp, file, nil
-}
-
-func (s *GoogleService) GetFileList() (*drive.FileList, error) {
-	return s.FilesService.List().Do()
-}
-
-func (s *GoogleService) GetSharedFileList(ownerEmail string) (*drive.FileList, error) {
-	q := fmt.Sprintf("'%s' in owners and sharedWithMe = true", ownerEmail)
-	return s.FilesService.List().Q(q).Do()
-}
-
-func (s *GoogleService) UpdateFileTitle(fileId string, title string) error {
-	file, err := s.GetFile(fileId)
-	if err != nil {
-		return err
-	}
-	file.Title = title
-	_, err = s.FilesService.Update(fileId, file).Do()
-	return err
-}
-
 func (s *GoogleService) CreateUserPermission(email string, role string) *drive.Permission {
 	return &drive.Permission{
 		Role:  role,

--- a/app/permission/googledrive.go
+++ b/app/permission/googledrive.go
@@ -5,22 +5,49 @@ import (
 	"github.com/kayac/alphawing/app/storage"
 )
 
+var defaultRole = "reader"
+
 type GoogleDrive struct {
 	Service *googleservice.GoogleService
 }
 
-func (gd *GoogleDrive) CreateGroup(name string) (storage.FileIdentifier, error) {
-	return storage.FileIdentifier, nil
+func (gd *GoogleDrive) CreateGroup(name string) (*storage.FileIdentifier, error) {
+	ident := &storage.FileIdentifier{}
+
+	file, err := gd.Service.CreateFolder(name)
+	if err != nil {
+		return ident, err
+	}
+
+	ident.FileId = file.Id
+	return ident, nil
 }
 
-func (gd *GoogleDrive) AddUser(email string) error {
-	return nil
+func (gd *GoogleDrive) AddUser(ident *storage.FileIdentifier, email string) error {
+	perm := gd.Service.CreateUserPermission(email, defaultRole)
+	_, err := gd.Service.InsertPermission(ident.FileId, perm)
+	return err
 }
 
-func (gd *GoogleDrive) DeleteUser(email string) error {
-	return nil
+func (gd *GoogleDrive) DeleteUser(ident *storage.FileIdentifier, email string) error {
+	permId, err := gd.Service.GetPermissionId(ident.FileId, email)
+	if err != nil {
+		return err
+	}
+
+	return gd.Service.DeletePermission(ident.FileId, permId)
 }
 
-func (gd *GoogleDrive) GetUserList(name string) ([]string, error) {
-	return []string{}, nil
+func (gd *GoogleDrive) GetUserList(ident *storage.FileIdentifier) ([]string, error) {
+	permList, err := gd.Service.GetPermissionList(ident.FileId)
+	if err != nil {
+		return err
+	}
+
+	var permIds []string
+	for _, perm := range permList.Items {
+		permIds = append(permIds, perm.Id)
+	}
+
+	return permIds, nil
 }

--- a/app/permission/googledrive.go
+++ b/app/permission/googledrive.go
@@ -8,16 +8,16 @@ type GoogleDrive struct {
 	Service *googleservice.GoogleService
 }
 
-func (gd *GoogleDrive) CreateGroup(name string) (string, error) {
+func (gd GoogleDrive) CreateGroup(name string) (string, error) {
 	file, err := gd.Service.CreateFolder(name)
 	if err != nil {
 		return "", err
 	}
 
-	return fild.Id, nil
+	return file.Id, nil
 }
 
-func (gd *GoogleDrive) AddUser(groupId string, email string) (string, error) {
+func (gd GoogleDrive) AddUser(groupId string, email string) (string, error) {
 	perm := gd.Service.CreateUserPermission(email, defaultRole)
 	insertedPerm, err := gd.Service.InsertPermission(groupId, perm)
 	if err != nil {
@@ -26,14 +26,14 @@ func (gd *GoogleDrive) AddUser(groupId string, email string) (string, error) {
 	return insertedPerm.Id, err
 }
 
-func (gd *GoogleDrive) DeleteUser(groupId string, permId string) error {
+func (gd GoogleDrive) DeleteUser(groupId string, permId string) error {
 	return gd.Service.DeletePermission(groupId, permId)
 }
 
-func (gd *GoogleDrive) GetUserList(groupId string) ([]string, error) {
+func (gd GoogleDrive) GetUserList(groupId string) ([]string, error) {
 	permList, err := gd.Service.GetPermissionList(groupId)
 	if err != nil {
-		return err
+		return []string{}, err
 	}
 
 	var permIds []string
@@ -44,6 +44,6 @@ func (gd *GoogleDrive) GetUserList(groupId string) ([]string, error) {
 	return permIds, nil
 }
 
-func (gd *GoogleDrive) DeleteGroup(groupId string) error {
+func (gd GoogleDrive) DeleteGroup(groupId string) error {
 	return gd.Service.FilesService.Delete(groupId).Do()
 }

--- a/app/permission/googledrive.go
+++ b/app/permission/googledrive.go
@@ -1,9 +1,6 @@
-package googledrive
+package permission
 
-import (
-	"github.com/kayac/alphawing/app/googleservice"
-	"github.com/kayac/alphawing/app/storage"
-)
+import "github.com/kayac/alphawing/app/googleservice"
 
 var defaultRole = "reader"
 
@@ -11,35 +8,30 @@ type GoogleDrive struct {
 	Service *googleservice.GoogleService
 }
 
-func (gd *GoogleDrive) CreateGroup(name string) (*storage.FileIdentifier, error) {
-	ident := &storage.FileIdentifier{}
-
+func (gd *GoogleDrive) CreateGroup(name string) (string, error) {
 	file, err := gd.Service.CreateFolder(name)
 	if err != nil {
-		return ident, err
+		return "", err
 	}
 
-	ident.FileId = file.Id
-	return ident, nil
+	return fild.Id, nil
 }
 
-func (gd *GoogleDrive) AddUser(ident *storage.FileIdentifier, email string) error {
+func (gd *GoogleDrive) AddUser(groupId string, email string) (string, error) {
 	perm := gd.Service.CreateUserPermission(email, defaultRole)
-	_, err := gd.Service.InsertPermission(ident.FileId, perm)
-	return err
-}
-
-func (gd *GoogleDrive) DeleteUser(ident *storage.FileIdentifier, email string) error {
-	permId, err := gd.Service.GetPermissionId(ident.FileId, email)
+	insertedPerm, err := gd.Service.InsertPermission(groupId, perm)
 	if err != nil {
-		return err
+		return "", err
 	}
-
-	return gd.Service.DeletePermission(ident.FileId, permId)
+	return insertedPerm.Id, err
 }
 
-func (gd *GoogleDrive) GetUserList(ident *storage.FileIdentifier) ([]string, error) {
-	permList, err := gd.Service.GetPermissionList(ident.FileId)
+func (gd *GoogleDrive) DeleteUser(groupId string, permId string) error {
+	return gd.Service.DeletePermission(groupId, permId)
+}
+
+func (gd *GoogleDrive) GetUserList(groupId string) ([]string, error) {
+	permList, err := gd.Service.GetPermissionList(groupId)
 	if err != nil {
 		return err
 	}
@@ -50,4 +42,8 @@ func (gd *GoogleDrive) GetUserList(ident *storage.FileIdentifier) ([]string, err
 	}
 
 	return permIds, nil
+}
+
+func (gd *GoogleDrive) DeleteGroup(groupId string) error {
+	return gd.Service.FilesService.Delete(groupId).Do()
 }

--- a/app/permission/googledrive.go
+++ b/app/permission/googledrive.go
@@ -1,0 +1,26 @@
+package googledrive
+
+import (
+	"github.com/kayac/alphawing/app/googleservice"
+	"github.com/kayac/alphawing/app/storage"
+)
+
+type GoogleDrive struct {
+	Service *googleservice.GoogleService
+}
+
+func (gd *GoogleDrive) CreateGroup(name string) (storage.FileIdentifier, error) {
+	return storage.FileIdentifier, nil
+}
+
+func (gd *GoogleDrive) AddUser(email string) error {
+	return nil
+}
+
+func (gd *GoogleDrive) DeleteUser(email string) error {
+	return nil
+}
+
+func (gd *GoogleDrive) GetUserList(name string) ([]string, error) {
+	return []string{}, nil
+}

--- a/app/permission/permission.go
+++ b/app/permission/permission.go
@@ -5,7 +5,6 @@ import "github.com/kayac/alphawing/app/storage"
 type Permission interface {
 	CreateGroup(name string) (ident storage.FileIdentifier, err error)
 	AddUser(email string) error
-	UpdateUser(email string) error
 	DeleteUser(email string) error
 	GetUserList(name string) (emails []string, err error)
 }

--- a/app/permission/permission.go
+++ b/app/permission/permission.go
@@ -2,8 +2,8 @@ package permission
 
 type Permission interface {
 	CreateGroup(name string) (groupId string, err error)
-	DeleteGroup(groupId string) (groupId string, err error)
+	DeleteGroup(groupId string) error
 	AddUser(groupId string, email string) (permId string, err error)
 	DeleteUser(groupId string, permId string) error
-	GetUserList(groupId string, name string) (emails []string, err error)
+	GetUserList(groupId string) (emails []string, err error)
 }

--- a/app/permission/permission.go
+++ b/app/permission/permission.go
@@ -1,10 +1,9 @@
 package permission
 
-import "github.com/kayac/alphawing/app/storage"
-
 type Permission interface {
-	CreateGroup(name string) (ident storage.FileIdentifier, err error)
-	AddUser(ident storage.FileIdentifier, email string) error
-	DeleteUser(ident storage.FileIdentifier, email string) error
-	GetUserList(ident storage.FileIdentifier, name string) (emails []string, err error)
+	CreateGroup(name string) (groupId string, err error)
+	DeleteGroup(groupId string) (groupId string, err error)
+	AddUser(groupId string, email string) (permId string, err error)
+	DeleteUser(groupId string, permId string) error
+	GetUserList(groupId string, name string) (emails []string, err error)
 }

--- a/app/permission/permission.go
+++ b/app/permission/permission.go
@@ -1,0 +1,11 @@
+package permission
+
+import "github.com/kayac/alphawing/app/storage"
+
+type Permission interface {
+	CreateGroup(name string) (ident storage.FileIdentifier, err error)
+	AddUser(email string) error
+	UpdateUser(email string) error
+	DeleteUser(email string) error
+	GetUserList(name string) (emails []string, err error)
+}

--- a/app/permission/permission.go
+++ b/app/permission/permission.go
@@ -4,7 +4,7 @@ import "github.com/kayac/alphawing/app/storage"
 
 type Permission interface {
 	CreateGroup(name string) (ident storage.FileIdentifier, err error)
-	AddUser(email string) error
-	DeleteUser(email string) error
-	GetUserList(name string) (emails []string, err error)
+	AddUser(ident storage.FileIdentifier, email string) error
+	DeleteUser(ident storage.FileIdentifier, email string) error
+	GetUserList(ident storage.FileIdentifier, name string) (emails []string, err error)
 }

--- a/app/storage/googledrive.go
+++ b/app/storage/googledrive.go
@@ -16,6 +16,18 @@ type GoogleDrive struct {
 	Parent  *drive.ParentReference
 }
 
+func NewGoogleDrive(service *googleservice.GoogleService, parentFileId string) (GoogleDrive, error) {
+	parent := &drive.ParentReference{
+		Id: parentFileId,
+	}
+	gd := GoogleDrive{
+		Service: service,
+		Parent:  parent,
+	}
+
+	return gd, nil
+}
+
 func (gd GoogleDrive) GetUrl(fileId string) (string, error) {
 	file, err := gd.Service.FilesService.Get(fileId).Do()
 	if err != nil {
@@ -39,7 +51,7 @@ func (gd GoogleDrive) DownloadFile(fileId string) (*http.Response, StorageFile, 
 		Filename: file.OriginalFilename,
 	}
 
-	resp, err := http.Get(file.DownloadUrl)
+	resp, err := gd.Service.Client.Get(file.DownloadUrl)
 	if err != nil {
 		return &http.Response{}, StorageFile{}, err
 	}

--- a/app/storage/googledrive.go
+++ b/app/storage/googledrive.go
@@ -2,7 +2,7 @@ package storage
 
 import (
 	"fmt"
-	"net/http"
+	"io"
 	"os"
 	"time"
 
@@ -36,15 +36,15 @@ func (gd GoogleDrive) GetUrl(fileId string) (string, error) {
 	return file.DownloadUrl, nil
 }
 
-func (gd GoogleDrive) DownloadFile(fileId string) (*http.Response, StorageFile, error) {
+func (gd GoogleDrive) DownloadFile(fileId string) (io.Reader, StorageFile, error) {
 	file, err := gd.Service.FilesService.Get(fileId).Do()
 	if err != nil {
-		return &http.Response{}, StorageFile{}, err
+		return nil, StorageFile{}, err
 	}
 
 	modtime, err := time.Parse(time.RFC3339, file.ModifiedDate)
 	if err != nil {
-		return &http.Response{}, StorageFile{}, err
+		return nil, StorageFile{}, err
 	}
 	storageFile := StorageFile{
 		Modtime:  modtime,
@@ -53,10 +53,10 @@ func (gd GoogleDrive) DownloadFile(fileId string) (*http.Response, StorageFile, 
 
 	resp, err := gd.Service.Client.Get(file.DownloadUrl)
 	if err != nil {
-		return &http.Response{}, StorageFile{}, err
+		return nil, StorageFile{}, err
 	}
 
-	return resp, storageFile, nil
+	return resp.Body, storageFile, nil
 }
 
 func (gd GoogleDrive) GetFileList(viewerEmail string) ([]string, error) {

--- a/app/storage/googledrive.go
+++ b/app/storage/googledrive.go
@@ -1,0 +1,40 @@
+package storage
+
+import (
+	"os"
+
+	"code.google.com/p/google-api-go-client/drive/v2"
+
+	"github.com/kayac/alphawing/app/googleservice"
+)
+
+type GoogleDrive struct {
+	Service *googleservice.GoogleService
+	Parent  *drive.ParentReference
+}
+
+func (gd *GoogleDrive) Upload(file *os.File, filename string) (FileIdentifier, error) {
+	driveFile := &drive.File{
+		Title:   filename,
+		Parents: []*drive.ParentReference{gd.Parent},
+	}
+
+	driveFile, err := gd.Service.FilesService.Insert(driveFile).Media(file).Do()
+	if err != nil {
+		return FileIdentifier{}, err
+	}
+
+	ident := FileIdentifier{
+		FileId:   driveFile.Id,
+		Filename: filename,
+	}
+	return ident, nil
+}
+
+func (gd *GoogleDrive) GetUrl(ident FileIdentifier) (string, error) {
+	return "", nil
+}
+
+func (gd *GoogleDrive) Delete(ident FileIdentifier) error {
+	return nil
+}

--- a/app/storage/googledrive.go
+++ b/app/storage/googledrive.go
@@ -36,5 +36,21 @@ func (gd *GoogleDrive) GetUrl(ident FileIdentifier) (string, error) {
 }
 
 func (gd *GoogleDrive) Delete(ident FileIdentifier) error {
+	return gd.Service.FilesService.Delete(ident.FileId).Do()
+}
+
+func (gd *GoogleDrive) DeleteAll() error {
+	fileList, err := gd.Service.FilesService.List().Do()
+	if err != nil {
+		return err
+	}
+
+	for _, file := range fileList.Items {
+		err = gd.Delete(FileIdentifier{FileId: file.Id})
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/app/storage/googledrive_test.go
+++ b/app/storage/googledrive_test.go
@@ -1,0 +1,13 @@
+package storage
+
+import "testing"
+
+func TestSatisfyGoogleDrive(t *testing.T) {
+	g := GoogleDrive{}
+
+	_, ok := interface{}(g).(Storage)
+
+	if !ok {
+		t.Error("storage.GoogleDrive is not satisfy of storage.Storage")
+	}
+}

--- a/app/storage/local.go
+++ b/app/storage/local.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 )
@@ -11,13 +10,13 @@ type Local struct {
 	Dir string
 }
 
-// implement not yet
+// not implemented yet
 func (l Local) GetUrl(fileId string) (string, error) {
 	return "", nil
 }
 
-func (l Local) DownloadFile(fileId string) (*http.Response, StorageFile, error) {
-	return &http.Response{}, StorageFile{}, nil
+func (l Local) DownloadFile(fileId string) (io.Reader, StorageFile, error) {
+	return nil, StorageFile{}, nil
 }
 
 func (l Local) GetFileList(viewerEmail string) ([]string, error) {

--- a/app/storage/local.go
+++ b/app/storage/local.go
@@ -1,13 +1,44 @@
 package storage
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 )
 
 type Local struct {
 	Dir string
+}
+
+func generateFileId(filename string) string {
+	now := time.Now()
+	hash := sha256.Sum256(append([]byte(filename), []byte(now.Format(time.RFC3339))...))
+	return hex.EncodeToString(hash[0:5])
+}
+
+func (l Local) searchFile(fileId string) (string, error) {
+	files, err := ioutil.ReadDir(l.Dir)
+	if err != nil {
+		return "", err
+	}
+	var targetBasename string
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), fileId) {
+			targetBasename = file.Name()
+			break
+		}
+	}
+
+	if targetBasename == "" {
+		return "", errors.New("file not exists by fileId")
+	}
+	return targetBasename, nil
 }
 
 // not implemented yet
@@ -16,8 +47,12 @@ func (l Local) GetUrl(fileId string) (string, error) {
 }
 
 func (l Local) DownloadFile(fileId string) (io.Reader, StorageFile, error) {
-	targetPath := filepath.Join(l.Dir, fileId)
-	target, err := os.Open(targetPath)
+	targetBasename, err := l.searchFile(fileId)
+	if err != nil {
+		return nil, StorageFile{}, err
+	}
+
+	target, err := os.Open(filepath.Join(l.Dir, targetBasename))
 	if err != nil {
 		return nil, StorageFile{}, err
 	}
@@ -26,9 +61,11 @@ func (l Local) DownloadFile(fileId string) (io.Reader, StorageFile, error) {
 	if err != nil {
 		return nil, StorageFile{}, err
 	}
+
+	filename := strings.Replace(targetBasename, fileId+"_", "", 1)
 	storageFile := StorageFile{
 		Modtime:  fileInfo.ModTime(),
-		Filename: fileId,
+		Filename: filename,
 	}
 
 	return target, storageFile, nil
@@ -39,7 +76,9 @@ func (l Local) GetFileList(viewerEmail string) ([]string, error) {
 }
 
 func (l Local) Upload(src *os.File, filename string) (string, error) {
-	dstPath := filepath.Join(l.Dir, filename)
+	fileId := generateFileId(filename)
+	basename := fileId + "_" + filename
+	dstPath := filepath.Join(l.Dir, basename)
 	dst, err := os.Create(dstPath)
 	if err != nil {
 		return "", err
@@ -50,11 +89,18 @@ func (l Local) Upload(src *os.File, filename string) (string, error) {
 		return "", err
 	}
 
-	return filename, dst.Close()
+	return fileId, dst.Close()
 }
 
 func (l Local) ChangeFilename(fileId string, filename string) error {
-	return nil
+	srcBasename, err := l.searchFile(fileId)
+	if err != nil {
+		return err
+	}
+	srcPath := filepath.Join(l.Dir, srcBasename)
+	dstPath := filepath.Join(l.Dir, fileId+"_"+filename)
+
+	return os.Rename(srcPath, dstPath)
 }
 
 func (l Local) Delete(fileId string) error {

--- a/app/storage/local.go
+++ b/app/storage/local.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+type Local struct {
+	Dir string
+}
+
+// implement not yet
+func (l Local) GetUrl(fileId string) (string, error) {
+	return "", nil
+}
+
+func (l Local) DownloadFile(fileId string) (*http.Response, StorageFile, error) {
+	return &http.Response{}, StorageFile{}, nil
+}
+
+func (l Local) GetFileList(viewerEmail string) ([]string, error) {
+	return nil, nil
+}
+
+func (l Local) Upload(src *os.File, filename string) (string, error) {
+	dstPath := filepath.Join(l.Dir, filename)
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := io.Copy(dst, src); err != nil {
+		dst.Close()
+		return "", err
+	}
+
+	return filename, dst.Close()
+}
+
+func (l Local) ChangeFilename(fileId string, filename string) error {
+	return nil
+}
+
+func (l Local) Delete(fileId string) error {
+	return nil
+}
+
+func (l Local) DeleteAll() error {
+	return nil
+}

--- a/app/storage/local.go
+++ b/app/storage/local.go
@@ -16,7 +16,22 @@ func (l Local) GetUrl(fileId string) (string, error) {
 }
 
 func (l Local) DownloadFile(fileId string) (io.Reader, StorageFile, error) {
-	return nil, StorageFile{}, nil
+	targetPath := filepath.Join(l.Dir, fileId)
+	target, err := os.Open(targetPath)
+	if err != nil {
+		return nil, StorageFile{}, err
+	}
+
+	fileInfo, err := target.Stat()
+	if err != nil {
+		return nil, StorageFile{}, err
+	}
+	storageFile := StorageFile{
+		Modtime:  fileInfo.ModTime(),
+		Filename: fileId,
+	}
+
+	return target, storageFile, nil
 }
 
 func (l Local) GetFileList(viewerEmail string) ([]string, error) {
@@ -30,7 +45,7 @@ func (l Local) Upload(src *os.File, filename string) (string, error) {
 		return "", err
 	}
 
-	if _, err := io.Copy(dst, src); err != nil {
+	if _, err = io.Copy(dst, src); err != nil {
 		dst.Close()
 		return "", err
 	}

--- a/app/storage/local_test.go
+++ b/app/storage/local_test.go
@@ -62,21 +62,18 @@ func TestUploadLocal(t *testing.T) {
 	l := Local{Dir: dstDir}
 
 	dstBasename := randStringForTestFile()
-	filename, err := l.Upload(src, dstBasename)
+	fileId, err := l.Upload(src, dstBasename)
 	if err != nil {
 		t.Fatal("unexpected error: ", err)
 	}
-	if filename != dstBasename {
-		t.Fatal("unexpected fileId: ", filename)
-	}
 
-	dst, err := os.Open(filepath.Join(dstDir, dstBasename))
+	dst, err := os.Open(filepath.Join(dstDir, fileId+"_"+dstBasename))
 	if err != nil {
 		t.Fatal("cannot open destination file: ", err)
 	}
 	defer dst.Close()
 
-	r, storageFile, err := l.DownloadFile(filename)
+	r, storageFile, err := l.DownloadFile(fileId)
 	if err != nil {
 		t.Fatal("unexpected error: ", err)
 	}
@@ -92,8 +89,14 @@ func TestUploadLocal(t *testing.T) {
 		t.Fatalf("unmatch read data: got %s, expected %s.", gotData, data)
 	}
 
-	if storageFile.Filename != filename {
-		t.Fatalf("unmatch filename: got %s, expected %s.", storageFile.Filename, filename)
+	if storageFile.Filename != dstBasename {
+		t.Fatalf("unmatch filename: got %s, expected %s.", storageFile.Filename, dstBasename)
+	}
+
+	newBasename := randStringForTestFile()
+	err = l.ChangeFilename(fileId, newBasename)
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
 	}
 
 }

--- a/app/storage/local_test.go
+++ b/app/storage/local_test.go
@@ -1,0 +1,65 @@
+package storage
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestSatisfyLocal(t *testing.T) {
+	l := Local{}
+
+	_, ok := interface{}(l).(Storage)
+
+	if !ok {
+		t.Error("storage.Local is not satisfy of storage.Storage")
+	}
+}
+
+func randStringForTestFile() string {
+	var n uint64
+	binary.Read(rand.Reader, binary.LittleEndian, &n)
+	return strconv.FormatUint(n, 36)
+}
+
+func TestUploadLocal(t *testing.T) {
+	tempParentDir := os.TempDir()
+	tempDir := filepath.Join(tempParentDir, randStringForTestFile())
+	err := os.Mkdir(tempDir, os.ModeTemporary|0755)
+	if err != nil {
+		t.Fatal("cannot create tempdir: ", err)
+	}
+	defer os.Remove(tempDir)
+
+	src, err := os.Create(filepath.Join(tempDir, randStringForTestFile()))
+	if err != nil {
+		t.Fatal("cannot create source file: ", err)
+	}
+	defer src.Close()
+
+	dstDir := filepath.Join(tempDir, randStringForTestFile())
+	if err != nil {
+		t.Fatal("cannot create destination dir: ", err)
+	}
+
+	err = os.Mkdir(dstDir, os.ModeTemporary|0755)
+	l := Local{Dir: dstDir}
+
+	dstBasename := randStringForTestFile()
+	filename, err := l.Upload(src, dstBasename)
+	if err != nil {
+		t.Fatal("unexpected error: ", err)
+	}
+	if filename != dstBasename {
+		t.Fatal("unexpected fileId: ", filename)
+	}
+
+	dst, err := os.Open(filepath.Join(dstDir, dstBasename))
+	if err != nil {
+		t.Fatal("cannot open destination file: ", err)
+	}
+	defer dst.Close()
+}

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -8,6 +8,7 @@ type Storage interface {
 	Upload(file *os.File, filename string) (ident FileIdentifier, err error)
 	GetUrl(identifier FileIdentifier) (url string, err error)
 	Delete(identifier FileIdentifier) error
+	DeleteAll() error
 }
 
 type FileIdentifier struct {

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -1,22 +1,23 @@
 package storage
 
 import (
+	"net/http"
 	"os"
+	"time"
 )
 
 type Storage interface {
-	GetUrl(identifier FileIdentifier) (url string, err error)
-	GetFile(identifier FileIdentifier) (file *os.File, err error)
+	GetUrl(fileId string) (url string, err error)
+	DownloadFile(fileId string) (resp *http.Response, file StorageFile, err error)
 	GetFileList(viewerEmail string) (fileIds []string, err error)
 
-	Upload(file *os.File, filename string) (ident FileIdentifier, err error)
-	ChangeFilename(identifier FileIdentifier, filename string) error
+	Upload(file *os.File, filename string) (fileId string, err error)
+	ChangeFilename(fileId string, filename string) error
 
-	Delete(identifier FileIdentifier) error
+	Delete(fileId string) error
 	DeleteAll() error
 }
 
-type FileIdentifier struct {
-	Filename string
-	FileId   string
+type StorageFile struct {
+	Modtime time.Time
 }

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -1,0 +1,17 @@
+package storage
+
+import (
+	"os"
+)
+
+type Storage interface {
+	Upload(file os.File, filename string) (url string, err error)
+	GetUrl(filename string) (url string, err error)
+	Delete(filename string) error
+}
+
+type NotFoundError struct{}
+
+func (e NotFoundError) Error() string {
+	return "Not found file in storage"
+}

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -1,14 +1,14 @@
 package storage
 
 import (
-	"net/http"
+	"io"
 	"os"
 	"time"
 )
 
 type Storage interface {
 	GetUrl(fileId string) (url string, err error)
-	DownloadFile(fileId string) (resp *http.Response, file StorageFile, err error)
+	DownloadFile(fileId string) (r io.Reader, file StorageFile, err error)
 	GetFileList(viewerEmail string) (fileIds []string, err error)
 
 	Upload(file *os.File, filename string) (fileId string, err error)

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -5,8 +5,13 @@ import (
 )
 
 type Storage interface {
-	Upload(file *os.File, filename string) (ident FileIdentifier, err error)
 	GetUrl(identifier FileIdentifier) (url string, err error)
+	GetFile(identifier FileIdentifier) (file *os.File, err error)
+	GetFileList(viewerEmail string) (fileIds []string, err error)
+
+	Upload(file *os.File, filename string) (ident FileIdentifier, err error)
+	ChangeFilename(identifier FileIdentifier, filename string) error
+
 	Delete(identifier FileIdentifier) error
 	DeleteAll() error
 }

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -5,13 +5,12 @@ import (
 )
 
 type Storage interface {
-	Upload(file os.File, filename string) (url string, err error)
-	GetUrl(filename string) (url string, err error)
-	Delete(filename string) error
+	Upload(file *os.File, filename string) (ident FileIdentifier, err error)
+	GetUrl(identifier FileIdentifier) (url string, err error)
+	Delete(identifier FileIdentifier) error
 }
 
-type NotFoundError struct{}
-
-func (e NotFoundError) Error() string {
-	return "Not found file in storage"
+type FileIdentifier struct {
+	Filename string
+	FileId   string
 }

--- a/app/storage/storage.go
+++ b/app/storage/storage.go
@@ -19,5 +19,6 @@ type Storage interface {
 }
 
 type StorageFile struct {
-	Modtime time.Time
+	Modtime  time.Time
+	Filename string
 }


### PR DESCRIPTION
### やること
- 直接Google Drive APIを叩いている部分をinterfaceで分離する
- 実装として従来のGoogle Drive APIを使うものとローカルを使うものと2つ用意する
- app.confでどのstorageを使うかを切り替えられるようにする

### 何故やるか
- interfaceになっていないのでテストしにくい
- Google Cloud Storageに容易に切り替えられるようにする準備

### 進捗
- [x] storage interfaceの定義
- [x] google drive apiを使う部分をstorage interfaceに沿って実装
- [ ] ローカルに保存するstorage interfaceを実装
- [ ] ローカルに保存するバージョンのテスト