### PR TITLE
revel 0.12.0 support

### DIFF
--- a/app/controllers/gorp.go
+++ b/app/controllers/gorp.go
@@ -10,8 +10,8 @@ import (
 	"github.com/kayac/alphawing/app/models"
 
 	"github.com/coopernurse/gorp"
+	"github.com/revel/modules/db/app"
 	"github.com/revel/revel"
-	"github.com/revel/revel/modules/db/app"
 )
 
 var (

--- a/conf/app.conf.sample
+++ b/conf/app.conf.sample
@@ -34,7 +34,7 @@ log.error.prefix = "ERROR "
 # The default language of this application.
 i18n.default_language=en
 
-module.static=github.com/revel/revel/modules/static
+module.static=github.com/revel/modules/static
 
 
 # limit per page. default 25
@@ -46,7 +46,7 @@ mode.dev=true
 results.pretty=true
 watch=true
 
-module.testrunner = github.com/revel/revel/modules/testrunner
+module.testrunner = github.com/revel/modules/testrunner
 
 log.trace.output = off
 log.info.output  = stderr

--- a/tests/apptest.go
+++ b/tests/apptest.go
@@ -1,16 +1,16 @@
 package tests
 
-import "github.com/revel/revel"
+import "github.com/revel/revel/testing"
 
 type AppTest struct {
-	revel.TestSuite
+	testing.TestSuite
 }
 
 func (t *AppTest) Before() {
 	println("Set up")
 }
 
-func (t AppTest) TestThatIndexPageWorks() {
+func (t *AppTest) TestThatIndexPageWorks() {
 	t.Get("/")
 	t.AssertOk()
 	t.AssertContentType("text/html; charset=utf-8")


### PR DESCRIPTION
revel 0.12.0 に破壊的な変更が入ったので、既存のコードが動かなくなっています。
それに対する対応です。

ref https://github.com/revel/revel/releases/tag/v0.12.0