### PR TITLE
CFBundleIdentifier を保持して plist に埋め込む

### DIFF
--- a/app/models/bundle.go
+++ b/app/models/bundle.go
@@ -145,7 +145,7 @@ func (bundle *Bundle) Plist(txn gorp.SqlExecutor, ipaUrl *url.URL) (*Plist, erro
 		return nil, err
 	}
 
-	return NewPlist(app.Title, bundle.BundleVersion, ipaUrl.String()), nil
+	return NewPlist(app.Title, bundle.BundleVersion, bundle.BundleIdentifier, ipaUrl.String()), nil
 }
 
 func (bundle *Bundle) PlistReader(txn gorp.SqlExecutor, ipaUrl *url.URL) (io.Reader, error) {

--- a/app/models/bundle.go
+++ b/app/models/bundle.go
@@ -66,15 +66,16 @@ func (ext BundleFileExtension) PlatformType() BundlePlatformType {
 }
 
 type Bundle struct {
-	Id            int                `db:"id"`
-	AppId         int                `db:"app_id"`
-	FileId        string             `db:"file_id"`
-	PlatformType  BundlePlatformType `db:"platform_type"`
-	BundleVersion string             `db:"bundle_version"`
-	Revision      int                `db:"revision"`
-	Description   string             `db:"description"`
-	CreatedAt     time.Time          `db:"created_at"`
-	UpdatedAt     time.Time          `db:"updated_at"`
+	Id               int                `db:"id"`
+	AppId            int                `db:"app_id"`
+	FileId           string             `db:"file_id"`
+	PlatformType     BundlePlatformType `db:"platform_type"`
+	BundleVersion    string             `db:"bundle_version"`
+	BundleIdentifier string             `db:"bundle_identifier"`
+	Revision         int                `db:"revision"`
+	Description      string             `db:"description"`
+	CreatedAt        time.Time          `db:"created_at"`
+	UpdatedAt        time.Time          `db:"updated_at"`
 
 	BundleInfo *BundleInfo `db:"-"`
 	File       *os.File    `db:"-"`
@@ -192,6 +193,7 @@ func (bundle *Bundle) App(txn gorp.SqlExecutor) (*App, error) {
 
 func (bundle *Bundle) PreInsert(s gorp.SqlExecutor) error {
 	bundle.BundleVersion = bundle.BundleInfo.Version
+	bundle.BundleIdentifier = bundle.BundleInfo.Identifier
 	bundle.CreatedAt = time.Now()
 	bundle.UpdatedAt = bundle.CreatedAt
 	return nil

--- a/app/models/bundleinfo.go
+++ b/app/models/bundleinfo.go
@@ -16,6 +16,7 @@ import (
 // a BundleInfo is information of an application package(apk file, ipa file, etc.)
 type BundleInfo struct {
 	Version      string
+	Identifier   string
 	PlatformType BundlePlatformType
 }
 
@@ -25,7 +26,8 @@ type androidManifest struct {
 }
 
 type iosInfo struct {
-	CFBundleVersion string `plist:"CFBundleVersion"`
+	CFBundleVersion    string `plist:"CFBundleVersion"`
+	CFBundleIdentifier string `plist:"CFBundleIdentifier"`
 }
 
 type BundleParseError struct {
@@ -141,6 +143,7 @@ func parseIpaFile(plistFile *zip.File) (*BundleInfo, error) {
 
 	bundleInfo := &BundleInfo{}
 	bundleInfo.Version = info.CFBundleVersion
+	bundleInfo.Identifier = info.CFBundleIdentifier
 	bundleInfo.PlatformType = BundlePlatformTypeIOS
 
 	return bundleInfo, nil

--- a/app/models/plist.go
+++ b/app/models/plist.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	PlistFileName            = "test.plist"
-	AssetKind                = "software-package"
-	MetadataBundleIdentifier = "com.example.test"
-	MetadataKind             = "software"
+	PlistFileName                   = "test.plist"
+	AssetKind                       = "software-package"
+	DefaultMetadataBundleIdentifier = "com.example.test"
+	MetadataKind                    = "software"
 )
 
 type Plist struct {
@@ -35,7 +35,11 @@ type Metadata struct {
 	Title            string `plist:"title"`
 }
 
-func NewPlist(title, version, ipaUrl string) *Plist {
+func NewPlist(title, version, identifier, ipaUrl string) *Plist {
+	if len(identifier) == 0 {
+		identifier = DefaultMetadataBundleIdentifier
+	}
+
 	return &Plist{
 		Items: []*Item{
 			&Item{
@@ -46,7 +50,7 @@ func NewPlist(title, version, ipaUrl string) *Plist {
 					},
 				},
 				Metadata: &Metadata{
-					BundleIdentifier: MetadataBundleIdentifier,
+					BundleIdentifier: identifier,
 					BundleVersion:    version,
 					Kind:             MetadataKind,
 					Title:            title,


### PR DESCRIPTION
全部同じ identifier を使っちゃうと、ダウンロードが終わったときに既に入ってるやつに上書きされるので、ダウンロードしたやつが消えたように見えてしまう。よって修正。