### PR TITLE
それぞれのOSタブについて、「もっと見る」処理をかける

### DIFF
--- a/static/_src/js/alphawing.js
+++ b/static/_src/js/alphawing.js
@@ -237,10 +237,11 @@ $(function () {
 
 
     // limit bundle entries
-    (function () {
+    $('.bundle-list__list').each(function (index, el) {
         var MAX_COUNT = 5;
-
-        var $root = $('.bundle-list__list');
+        
+        var $root = $(el);
+        
         if (!$root.length) {
             return;
         }
@@ -273,5 +274,5 @@ $(function () {
             $more.remove();
             $item.show();
         });
-    })();
+    });
 });

--- a/static/js/alphawing.js
+++ b/static/js/alphawing.js
@@ -238,10 +238,11 @@ $(function () {
 
 
     // limit bundle entries
-    (function () {
+    $('.bundle-list__list').each(function (index, el) {
         var MAX_COUNT = 5;
-
-        var $root = $('.bundle-list__list');
+        
+        var $root = $(el);
+        
         if (!$root.length) {
             return;
         }
@@ -274,7 +275,7 @@ $(function () {
             $more.remove();
             $item.show();
         });
-    })();
+    });
 });
 
 })();


### PR DESCRIPTION
#73 の実装時にバグがあった。
OSのタブ（iOS・Android）が両方表示されている際、もっと見るボタンとbundle listの対応が不正だったので、タブの数だけ同様の処理をかけるように修正。